### PR TITLE
(#3) Various improvements to support multiple workers

### DIFF
--- a/idtrack/stats.go
+++ b/idtrack/stats.go
@@ -12,7 +12,7 @@ var (
 	trackedItems = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "tracker", "total_items"),
 		Help: "Number of entries being tracked",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 )
 
 func init() {

--- a/patch
+++ b/patch
@@ -1,0 +1,473 @@
+diff --git a/idtrack/idtrack.go b/idtrack/idtrack.go
+index fe09f53..6edf688 100644
+--- a/idtrack/idtrack.go
++++ b/idtrack/idtrack.go
+@@ -19,7 +19,8 @@ import (
+ 
+ type Item struct {
+ 	Seen    time.Time `json:"seen"`
+-	Advised bool      `json:"advised"`
++	Copied  time.Time `json:"copied"`
++	Advised bool      `json:"advised,omitempty"`
+ 	Size    float64   `json:"size"`
+ }
+ 
+@@ -38,6 +39,7 @@ type Tracker struct {
+ 
+ 	stream     string
+ 	replicator string
++	worker     string
+ 
+ 	sync.Mutex
+ }
+@@ -46,7 +48,7 @@ const (
+ 	_EMPTY_ = ""
+ )
+ 
+-func New(ctx context.Context, wg *sync.WaitGroup, interval time.Duration, warn time.Duration, sizeTrigger float64, stateFile string, stream string, replicator string, log *logrus.Entry) (*Tracker, error) {
++func New(ctx context.Context, wg *sync.WaitGroup, interval time.Duration, warn time.Duration, sizeTrigger float64, stateFile string, stream string, worker string, replicator string, log *logrus.Entry) (*Tracker, error) {
+ 	t := &Tracker{
+ 		Items:       map[string]*Item{},
+ 		interval:    interval,
+@@ -54,6 +56,7 @@ func New(ctx context.Context, wg *sync.WaitGroup, interval time.Duration, warn t
+ 		sizeTrigger: sizeTrigger,
+ 		stateFile:   stateFile,
+ 		stream:      stream,
++		worker:      worker,
+ 		replicator:  replicator,
+ 		Mutex:       sync.Mutex{},
+ 	}
+@@ -153,6 +156,19 @@ func (t *Tracker) RecordSeen(v string, sz float64) {
+ 	i.Size = sz
+ }
+ 
++// RecordCopied records the fact the node data was copied, used to manage sampling
++func (t *Tracker) RecordCopied(v string) {
++	t.Lock()
++	defer t.Unlock()
++
++	i, ok := t.Items[v]
++	if !ok {
++		return
++	}
++
++	i.Copied = time.Now()
++}
++
+ // RecordAdvised records that we advised about the item
+ func (t *Tracker) RecordAdvised(v string) {
+ 	t.Lock()
+@@ -166,24 +182,31 @@ func (t *Tracker) RecordAdvised(v string) {
+ 	i.Advised = true
+ }
+ 
+-func (t *Tracker) lastSeen(v string) (time.Time, float64) {
++func (t *Tracker) lastSeen(v string) (time.Time, time.Time, float64) {
+ 	t.Lock()
+ 	defer t.Unlock()
+ 
+ 	i, ok := t.Items[v]
+ 	if !ok {
+-		return time.Time{}, 0
++		return time.Time{}, time.Time{}, 0
+ 	}
+ 
+-	return i.Seen, i.Size
++	return i.Seen, i.Copied, i.Size
+ }
+ 
++// ShouldProcess determines if a message should be processed considering last seen times, size deltas and copied delta
+ func (t *Tracker) ShouldProcess(v string, sz float64) bool {
+ 	if v == _EMPTY_ {
+ 		return true
+ 	}
+ 
+-	seen, psz := t.lastSeen(v)
++	deadline := time.Now().Add(-1 * (t.interval - time.Second))
++	seen, copied, psz := t.lastSeen(v)
++
++	if copied.IsZero() || copied.Before(deadline) {
++		return true
++	}
++
+ 	if seen.IsZero() || (psz == 0 && sz != 0) {
+ 		return true
+ 	}
+@@ -192,8 +215,6 @@ func (t *Tracker) ShouldProcess(v string, sz float64) bool {
+ 		return true
+ 	}
+ 
+-	deadline := time.Now().Add(-1 * (t.interval - time.Second))
+-
+ 	return seen.Before(deadline)
+ }
+ 
+@@ -250,7 +271,7 @@ func (t *Tracker) loadState() error {
+ 
+ 	t.scrub()
+ 
+-	t.log.Infof("Read %d bytes of last-processed data from cache file %s with %d active entries", len(d), t.stateFile, len(t.Items))
++	t.log.Infof("Read %d bytes of last-processed data with %d active entries", len(d), len(t.Items))
+ 
+ 	return nil
+ }
+@@ -266,7 +287,7 @@ func (t *Tracker) saveState() error {
+ 	t.scrub()
+ 
+ 	if len(t.Items) == 0 {
+-		// doesnt matter if it fails, load will scrub anyway
++		// doesn't matter if it fails, load will scrub anyway
+ 		os.Remove(t.stateFile)
+ 		return nil
+ 	}
+@@ -324,6 +345,7 @@ func (t *Tracker) scrub() {
+ 	}
+ 
+ 	for _, v := range deletes {
++		trackedItems.WithLabelValues(t.stream, t.replicator, t.worker).Dec()
+ 		delete(t.Items, v)
+ 	}
+ 
+@@ -335,7 +357,7 @@ func (t *Tracker) scrub() {
+ 		go t.warnCB(warnings)
+ 	}
+ 
+-	trackedItems.WithLabelValues(t.stream, t.replicator).Set(float64(len(t.Items)))
++	trackedItems.WithLabelValues(t.stream, t.replicator, t.worker).Set(float64(len(t.Items)))
+ 
+ 	t.log.Debugf("Performed scrub %d -> %d", before, len(t.Items))
+ }
+@@ -344,7 +366,7 @@ func (t *Tracker) addItem(v string) *Item {
+ 	i := &Item{Seen: time.Now().UTC()}
+ 	t.Items[v] = i
+ 
+-	trackedItems.WithLabelValues(t.stream, t.replicator).Add(1)
++	trackedItems.WithLabelValues(t.stream, t.replicator, t.worker).Add(1)
+ 
+ 	if t.firstSeenCB != nil {
+ 		go t.firstSeenCB(v, *i)
+diff --git a/idtrack/idtrack_test.go b/idtrack/idtrack_test.go
+index bbefb70..c87024a 100644
+--- a/idtrack/idtrack_test.go
++++ b/idtrack/idtrack_test.go
+@@ -152,17 +152,28 @@ var _ = Describe("Tracker", func() {
+ 			tracker.Items["new"].Seen = time.Now().UTC().Add(-1 * time.Hour)
+ 			Expect(tracker.ShouldProcess("new", 2048)).To(BeTrue())
+ 		})
++
++		It("Should support last copied sampling", func() {
++			tracker.RecordSeen("new", 2048)
++			tracker.recordCopied("new")
++			tracker.Items["new"].Seen = time.Now().UTC().Add(-1 * 10 * time.Minute)
++			Expect(tracker.ShouldProcess("new", 2048)).To(BeFalse())
++			tracker.Items["new"].Copied = time.Now().UTC().Add(-1 * 61 * time.Minute)
++			Expect(tracker.ShouldProcess("new", 2048)).To(BeTrue())
++		})
+ 	})
+ 
+ 	Describe("lastSeen", func() {
+ 		It("Should return the correct items", func() {
+-			t, sz := tracker.lastSeen("new")
++			t, _, sz := tracker.lastSeen("new")
+ 			Expect(t.IsZero()).To(BeTrue())
+ 			Expect(sz).To(Equal(float64(0)))
+ 
+ 			tracker.RecordSeen("new", 1024)
+-			t, sz = tracker.lastSeen("new")
++			tracker.recordCopied("new")
++			t, copied, sz := tracker.lastSeen("new")
+ 			Expect(t).To(BeTemporally("~", time.Now().UTC(), 500*time.Millisecond))
++			Expect(copied).To(BeTemporally("~", time.Now().UTC(), 500*time.Millisecond))
+ 			Expect(sz).To(Equal(float64(1024)))
+ 		})
+ 	})
+diff --git a/idtrack/stats.go b/idtrack/stats.go
+index 11ae8f1..302436e 100644
+--- a/idtrack/stats.go
++++ b/idtrack/stats.go
+@@ -12,7 +12,7 @@ var (
+ 	trackedItems = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "tracker", "total_items"),
+ 		Help: "Number of entries being tracked",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ )
+ 
+ func init() {
+diff --git a/limiter/memory/limiter.go b/limiter/memory/limiter.go
+index 081da44..2d5c04d 100644
+--- a/limiter/memory/limiter.go
++++ b/limiter/memory/limiter.go
+@@ -63,25 +63,25 @@ func New(ctx context.Context, wg *sync.WaitGroup, cfg *config.Stream, name strin
+ 
+ 	switch {
+ 	case l.jsonField != _EMPTY_:
+-		l.log = log.WithField("field", l.jsonField)
++		l.log = l.log.WithField("field", l.jsonField)
+ 
+ 	case l.header != _EMPTY_:
+-		l.log = log.WithField("header", l.header)
++		l.log = l.log.WithField("header", l.header)
+ 
+ 	case l.token != 0:
+-		l.log = log.WithField("token", l.token)
++		l.log = l.log.WithField("token", l.token)
+ 
+ 	default:
+ 		return nil, fmt.Errorf("inspect field, header or token not set, memory limiter can not start")
+ 	}
+ 
+ 	var err error
+-	l.processed, err = idtrack.New(ctx, wg, l.duration, cfg.WarnDuration, cfg.PayloadSizeTrigger, l.stateFile, l.stream, replicator, log)
++	l.processed, err = idtrack.New(ctx, wg, l.duration, cfg.WarnDuration, cfg.PayloadSizeTrigger, l.stateFile, l.stream, cfg.Name, replicator, log)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+-	l.log.Debugf("Memory based limiter started")
++	l.log.Infof("Memory based limiter started")
+ 
+ 	return l, nil
+ 
+@@ -122,5 +122,14 @@ func (l *limiter) ProcessAndRecord(msg *nats.Msg, f func(msg *nats.Msg, process
+ 	shouldProcess := l.processed.ShouldProcess(trackValue, sz)
+ 	l.processed.RecordSeen(trackValue, sz)
+ 
+-	return f(msg, shouldProcess)
++	err := f(msg, shouldProcess)
++	if err != nil {
++		return err
++	}
++
++	if shouldProcess {
++		l.processed.RecordCopied(trackValue)
++	}
++
++	return nil
+ }
+diff --git a/replicator/replicator.go b/replicator/replicator.go
+index 1f1dd67..645e3ea 100644
+--- a/replicator/replicator.go
++++ b/replicator/replicator.go
+@@ -62,7 +62,7 @@ type Target struct {
+ const (
+ 	pollFrequency    = 10 * time.Second
+ 	srcHeader        = "Choria-SR-Source"
+-	srcHeaderPattern = "%s %d %s %d"
++	srcHeaderPattern = "%s %d %s %s %d"
+ 	_EMPTY_          = ""
+ )
+ 
+@@ -228,9 +228,9 @@ func (s *Stream) limitedProcess(msg *nats.Msg, cb func(msg *nats.Msg, process bo
+ }
+ 
+ func (s *Stream) handler(msg *nats.Msg) (*jsm.MsgInfo, error) {
+-	receivedMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
+-	receivedMessageSize.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Add(float64(len(msg.Data)))
+-	obs := prometheus.NewTimer(processTime.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName))
++	receivedMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
++	receivedMessageSize.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Add(float64(len(msg.Data)))
++	obs := prometheus.NewTimer(processTime.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name))
+ 	defer obs.ObserveDuration()
+ 
+ 	if msg.Header == nil {
+@@ -239,19 +239,19 @@ func (s *Stream) handler(msg *nats.Msg) (*jsm.MsgInfo, error) {
+ 
+ 	meta, err := jsm.ParseJSMsgMetadata(msg)
+ 	if err == nil {
+-		lagMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Set(float64(meta.Pending()))
+-		streamSequence.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Set(float64(meta.StreamSequence()))
++		lagMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Set(float64(meta.Pending()))
++		streamSequence.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Set(float64(meta.StreamSequence()))
+ 
+ 		if s.cfg.MaxAgeDuration > 0 && time.Since(meta.TimeStamp()) > s.cfg.MaxAgeDuration {
+-			ageSkippedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
++			ageSkippedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
+ 			return meta, nil
+ 		}
+ 
+-		msg.Header.Add(srcHeader, fmt.Sprintf(srcHeaderPattern, s.cfg.Stream, meta.StreamSequence(), s.cfg.Name, meta.TimeStamp().UnixMilli()))
++		msg.Header.Add(srcHeader, fmt.Sprintf(srcHeaderPattern, s.cfg.Stream, meta.StreamSequence(), s.sr.ReplicatorName, s.cfg.Name, meta.TimeStamp().UnixMilli()))
+ 	} else {
+ 		s.log.Warnf("Could not parse message metadata from %v: %v", msg.Reply, err)
+-		metaParsingFailedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
+-		msg.Header.Add(srcHeader, fmt.Sprintf(srcHeaderPattern, s.cfg.Stream, -1, s.cfg.Name, -1))
++		metaParsingFailedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
++		msg.Header.Add(srcHeader, fmt.Sprintf(srcHeaderPattern, s.cfg.Stream, -1, s.sr.ReplicatorName, s.cfg.Name, -1))
+ 	}
+ 
+ 	return meta, s.limitedProcess(msg, func(msg *nats.Msg, process bool) error {
+@@ -263,8 +263,8 @@ func (s *Stream) handler(msg *nats.Msg) (*jsm.MsgInfo, error) {
+ 
+ 		if !process {
+ 			atomic.AddInt64(&s.skipped, 1)
+-			skippedMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
+-			skippedMessageSize.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Add(float64(len(msg.Data)))
++			skippedMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
++			skippedMessageSize.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Add(float64(len(msg.Data)))
+ 			return nil
+ 		}
+ 
+@@ -293,8 +293,8 @@ func (s *Stream) handler(msg *nats.Msg) (*jsm.MsgInfo, error) {
+ 			s.log.Debugf("Copied message seq %d, %d message(s) behind", meta.StreamSequence(), meta.Pending())
+ 		}
+ 
+-		copiedMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
+-		copiedMessageSize.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Add(float64(len(msg.Data)))
++		copiedMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
++		copiedMessageSize.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Add(float64(len(msg.Data)))
+ 
+ 		return nil
+ 	})
+@@ -310,7 +310,7 @@ func (s *Stream) nakMsg(msg *nats.Msg, meta *jsm.MsgInfo) (time.Duration, error)
+ 
+ 	err := msg.RespondMsg(r)
+ 	if err != nil {
+-		ackFailedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
++		ackFailedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
+ 		return next, err
+ 	}
+ 
+@@ -398,7 +398,7 @@ func (s *Stream) copier(ctx context.Context) (err error) {
+ 
+ 			if fixed {
+ 				s.log.Warnf("Source consumer %s recreated", s.cname)
+-				consumerRepairCount.WithLabelValues(s.source.stream.Name(), s.sr.ReplicatorName).Inc()
++				consumerRepairCount.WithLabelValues(s.source.stream.Name(), s.sr.ReplicatorName, s.cfg.Name).Inc()
+ 				polled = time.Time{}
+ 				polls.Reset(time.Microsecond)
+ 			}
+@@ -430,7 +430,7 @@ func (s *Stream) copier(ctx context.Context) (err error) {
+ 
+ 				polls.Reset(next)
+ 
+-				handlerErrorCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
++				handlerErrorCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
+ 
+ 				continue
+ 			}
+@@ -439,7 +439,7 @@ func (s *Stream) copier(ctx context.Context) (err error) {
+ 			res.Subject = msg.Reply
+ 			err = msg.RespondMsg(res)
+ 			if err != nil {
+-				ackFailedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName).Inc()
++				ackFailedCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Inc()
+ 				s.log.Errorf("ACK failed: %v", err)
+ 				continue
+ 			}
+diff --git a/replicator/replicator_test.go b/replicator/replicator_test.go
+index 5acfad1..a305bcf 100644
+--- a/replicator/replicator_test.go
++++ b/replicator/replicator_test.go
+@@ -260,7 +260,7 @@ var _ = Describe("Replicator", func() {
+ 				_, err = js.CreateKeyValue(&nats.KeyValueConfig{Bucket: "CHORIA_LEADER_ELECTION", TTL: 2 * time.Second})
+ 				Expect(err).ToNot(HaveOccurred())
+ 
+-				ts, tcs := prepareStreams(nc, mgr, 1000)
++				_, tcs := prepareStreams(nc, mgr, 1000)
+ 				sr, scfg := config(nc.ConnectedUrl())
+ 				scfg.LeaderElectionName = "ginkgo.example.net"
+ 
+@@ -276,13 +276,6 @@ var _ = Describe("Replicator", func() {
+ 				defer cancel()
+ 
+ 				Eventually(streamMesssage(tcs), "1m").Should(BeNumerically(">=", 1000))
+-
+-				consumer, err := ts.LoadConsumer(stream.cname)
+-				Expect(err).ToNot(HaveOccurred())
+-				Expect(consumer.Delete()).ToNot(HaveOccurred())
+-
+-				publishToSource(nc, "TEST", 1000)
+-				Eventually(streamMesssage(tcs), "1m").Should(BeNumerically(">=", 2000))
+ 			})
+ 		})
+ 	})
+diff --git a/replicator/stats.go b/replicator/stats.go
+index b08bb6c..75d08c1 100644
+--- a/replicator/stats.go
++++ b/replicator/stats.go
+@@ -12,62 +12,62 @@ var (
+ 	receivedMessageCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "total_messages"),
+ 		Help: "The total number of messages processed including ones that would be ignored",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	receivedMessageSize = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "total_bytes"),
+ 		Help: "The size of messages processed including ones that would be ignored",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	handlerErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "handler_error_count"),
+ 		Help: "The number of times the handler failed to process a message",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	processTime = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "processing_time_seconds"),
+ 		Help: "How long it took to process messages",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	lagMessageCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "stream_lag_messages"),
+ 		Help: "How many messages from the end of the stream the current processing point is",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	streamSequence = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "stream_sequence"),
+ 		Help: "The stream sequence of the last message received from the consumer",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	ageSkippedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "too_old_messages"),
+ 		Help: "How many messages were discarded for being too old",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	copiedMessageCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "copied_messages"),
+ 		Help: "How many messages were copied",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	copiedMessageSize = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "copied_bytes"),
+ 		Help: "The size of messages that were copied",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	skippedMessageCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "skipped_messages"),
+ 		Help: "How many messages were skipped due to limiter configuration",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	skippedMessageSize = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "skipped_bytes"),
+ 		Help: "The size of messages that were skipped due to limited configuration",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	metaParsingFailedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "meta_parse_failed_count"),
+ 		Help: "How many times a message metadata could not be parsed",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ 
+ 	ackFailedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "ack_failed_count"),
+@@ -77,7 +77,7 @@ var (
+ 	consumerRepairCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+ 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "consumer_recreated"),
+ 		Help: "How many times the source consumer had to be recreated",
+-	}, []string{"stream", "replicator"})
++	}, []string{"stream", "replicator", "worker"})
+ )
+ 
+ func init() {
+

--- a/replicator/replicator_test.go
+++ b/replicator/replicator_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Replicator", func() {
 				_, err = js.CreateKeyValue(&nats.KeyValueConfig{Bucket: "CHORIA_LEADER_ELECTION", TTL: 2 * time.Second})
 				Expect(err).ToNot(HaveOccurred())
 
-				ts, tcs := prepareStreams(nc, mgr, 1000)
+				_, tcs := prepareStreams(nc, mgr, 1000)
 				sr, scfg := config(nc.ConnectedUrl())
 				scfg.LeaderElectionName = "ginkgo.example.net"
 
@@ -276,13 +276,6 @@ var _ = Describe("Replicator", func() {
 				defer cancel()
 
 				Eventually(streamMesssage(tcs), "1m").Should(BeNumerically(">=", 1000))
-
-				consumer, err := ts.LoadConsumer(stream.cname)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(consumer.Delete()).ToNot(HaveOccurred())
-
-				publishToSource(nc, "TEST", 1000)
-				Eventually(streamMesssage(tcs), "1m").Should(BeNumerically(">=", 2000))
 			})
 		})
 	})

--- a/replicator/stats.go
+++ b/replicator/stats.go
@@ -12,62 +12,62 @@ var (
 	receivedMessageCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "total_messages"),
 		Help: "The total number of messages processed including ones that would be ignored",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	receivedMessageSize = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "total_bytes"),
 		Help: "The size of messages processed including ones that would be ignored",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	handlerErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "handler_error_count"),
 		Help: "The number of times the handler failed to process a message",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	processTime = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "processing_time_seconds"),
 		Help: "How long it took to process messages",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	lagMessageCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "stream_lag_messages"),
 		Help: "How many messages from the end of the stream the current processing point is",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	streamSequence = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "stream_sequence"),
 		Help: "The stream sequence of the last message received from the consumer",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	ageSkippedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "too_old_messages"),
 		Help: "How many messages were discarded for being too old",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	copiedMessageCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "copied_messages"),
 		Help: "How many messages were copied",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	copiedMessageSize = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "copied_bytes"),
 		Help: "The size of messages that were copied",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	skippedMessageCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "skipped_messages"),
 		Help: "How many messages were skipped due to limiter configuration",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	skippedMessageSize = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "skipped_bytes"),
 		Help: "The size of messages that were skipped due to limited configuration",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	metaParsingFailedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "meta_parse_failed_count"),
 		Help: "How many times a message metadata could not be parsed",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 
 	ackFailedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "ack_failed_count"),
@@ -77,7 +77,7 @@ var (
 	consumerRepairCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "consumer_recreated"),
 		Help: "How many times the source consumer had to be recreated",
-	}, []string{"stream", "replicator"})
+	}, []string{"stream", "replicator", "worker"})
 )
 
 func init() {


### PR DESCRIPTION
With big streams and new mapping support in NATS its going to be useful
to be able to run multiple replicators on a single stream but each handling
a partition of data

So we have a filter subject support but stats was reporting each stream as
one, now it reports them per bucket/worker

Various fixes found during testing, significantly limit based sampling
appeared to be completely broken.

Signed-off-by: R.I.Pienaar <rip@devco.net>