### PR TITLE
(#44) zero some stats when not the leaders

### DIFF
--- a/idtrack/idtrack.go
+++ b/idtrack/idtrack.go
@@ -328,6 +328,8 @@ func (t *Tracker) scrub() {
 	before := len(t.Items)
 
 	expireDeadline := time.Now().Add(-1 * t.interval)
+	// to avoid notifying about old stuff loaded from disk etc
+	expireIgnoreDeadline := time.Now().Add(-2 * t.interval)
 	expired := map[string]Item{}
 	shouldExpire := t.expireCB != nil
 
@@ -339,7 +341,7 @@ func (t *Tracker) scrub() {
 
 	for v, item := range t.Items {
 		if item.Seen.Before(expireDeadline) {
-			if shouldExpire {
+			if shouldExpire && !item.Seen.Before(expireIgnoreDeadline) {
 				expired[v] = *item
 			}
 			deletes = append(deletes, v)

--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -201,6 +201,10 @@ func (s *Stream) setupElection(ctx context.Context) error {
 		if s.advisor != nil {
 			s.advisor.Pause()
 		}
+
+		lagMessageCount.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Set(0)
+		streamSequence.WithLabelValues(s.cfg.Stream, s.sr.ReplicatorName, s.cfg.Name).Set(0)
+
 		s.mu.Unlock()
 	}
 
@@ -524,6 +528,10 @@ func (s *Stream) healthCheckSource() (fixed bool, err error) {
 	}
 
 	stream := s.source.stream
+	if stream == nil {
+		return false, fmt.Errorf("stream %s does not exist, cannot recover consumer", s.cfg.Stream)
+	}
+
 	s.source.consumer, err = stream.LoadConsumer(s.cname)
 	if jsm.IsNatsError(err, 10014) {
 		s.log.Errorf("Consumer %s was not found, attempting to recreate", s.cname)


### PR DESCRIPTION
Also do not send ancient advisories to deal with old state
items when switching to leader or loading from disk

Signed-off-by: R.I.Pienaar <rip@devco.net>