### PR TITLE
(#3) gossip sync id track state

### DIFF
--- a/idtrack/idtrack_test.go
+++ b/idtrack/idtrack_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Tracker", func() {
 		Expect(err).ToNot(HaveOccurred())
 		td.Close()
 
-		tracker, err = New(ctx, &wg, 60*time.Minute, 30*time.Minute, 1024, td.Name(), "TEST", "1", "GINKGO", log)
+		tracker, err = New(ctx, &wg, 60*time.Minute, 30*time.Minute, 1024, td.Name(), "TEST", "1", "GINKGO", nil, "", log)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -158,10 +158,11 @@ var _ = Describe("Tracker", func() {
 		})
 
 		It("Should correctly handle the deadline", func() {
+			tracker.noScrub = true
 			tracker.RecordSeen("new", 2048)
 			tracker.RecordCopied("new")
 
-			tracker.Items["new"].Seen = time.Now().UTC().Add(-1 * 59 * time.Minute)
+			tracker.Items["new"].Seen = time.Now().UTC().Add(-1 * 50 * time.Minute)
 			Expect(tracker.ShouldProcess("new", 2048)).To(BeFalse())
 			tracker.Items["new"].Seen = time.Now().UTC().Add(-1 * time.Hour)
 			Expect(tracker.ShouldProcess("new", 2048)).To(BeTrue())

--- a/idtrack/stats.go
+++ b/idtrack/stats.go
@@ -13,8 +13,14 @@ var (
 		Name: prometheus.BuildFQName("choria_stream_replicator", "tracker", "total_items"),
 		Help: "Number of entries being tracked",
 	}, []string{"stream", "replicator", "worker"})
+
+	seenByGossip = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName("choria_stream_replicator", "tracker", "seen_by_gossip"),
+		Help: "Number of entries that we learned about via gossip synchronization",
+	}, []string{"stream", "replicator", "worker"})
 )
 
 func init() {
 	prometheus.MustRegister(trackedItems)
+	prometheus.MustRegister(seenByGossip)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,6 +26,7 @@ type TLSConfig interface {
 func ConnectNats(ctx context.Context, name string, srv string, tls TLSConfig, oldStyle bool, log *logrus.Entry) (nc *nats.Conn, err error) {
 	opts := []nats.Option{
 		nats.MaxReconnects(-1),
+		nats.NoEcho(),
 		nats.Name(fmt.Sprintf("Choria Stream Replicator: %s", name)),
 		nats.CustomReconnectDelay(func(n int) time.Duration {
 			d := backoff.TwoMinutesSlowStart.Duration(n)

--- a/limiter/memory/limiter_test.go
+++ b/limiter/memory/limiter_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Limiter", func() {
 	Describe("ProcessAndRecord", func() {
 		It("Should handle missing fields", func() {
 			cfg.InspectJSONField = "sender"
-			limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+			limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 			Expect(err).ToNot(HaveOccurred())
 
 			msg := nats.NewMsg("test")
@@ -69,7 +69,7 @@ var _ = Describe("Limiter", func() {
 
 		It("Should handle present json fields", func() {
 			cfg.InspectJSONField = "sender"
-			limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+			limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 			Expect(err).ToNot(HaveOccurred())
 
 			msg := nats.NewMsg("test")
@@ -97,7 +97,7 @@ var _ = Describe("Limiter", func() {
 
 	It("Should handle absent token values", func() {
 		cfg.InspectSubjectToken = 10
-		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 		Expect(err).ToNot(HaveOccurred())
 
 		msg := nats.NewMsg("test")
@@ -115,7 +115,7 @@ var _ = Describe("Limiter", func() {
 
 	It("Should handle full subject inspections", func() {
 		cfg.InspectSubjectToken = -1
-		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 		Expect(err).ToNot(HaveOccurred())
 
 		msg := nats.NewMsg("test.1")
@@ -146,7 +146,7 @@ var _ = Describe("Limiter", func() {
 
 	It("Should handle present token values", func() {
 		cfg.InspectSubjectToken = 2
-		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 		Expect(err).ToNot(HaveOccurred())
 
 		msg := nats.NewMsg("test.1")
@@ -177,7 +177,7 @@ var _ = Describe("Limiter", func() {
 
 	It("Should handle absent header values", func() {
 		cfg.InspectHeaderValue = "sender"
-		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 		Expect(err).ToNot(HaveOccurred())
 
 		msg := nats.NewMsg("test")
@@ -194,7 +194,7 @@ var _ = Describe("Limiter", func() {
 
 	It("Should handle present header values", func() {
 		cfg.InspectHeaderValue = "sender"
-		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", log)
+		limiter, err := New(ctx, &wg, cfg, "GINKGO", "GINKGO", nil, log)
 		Expect(err).ToNot(HaveOccurred())
 
 		msg := nats.NewMsg("test")


### PR DESCRIPTION
This adds a basic gossip based idtrack syncer, its not perfect
but will do well to keep floods of advisories in check when
simply doing normal election leader changes during maintenance

Signed-off-by: R.I.Pienaar <rip@devco.net>