### PR TITLE
(#53) attempt to handle purges on target streams better

### DIFF
--- a/replicator/replicator.go
+++ b/replicator/replicator.go
@@ -49,14 +49,15 @@ type Stream struct {
 }
 
 type Target struct {
-	mgr       *jsm.Manager
-	stream    *jsm.Stream
-	consumer  *jsm.Consumer
-	cfg       api.StreamConfig
-	nc        *nats.Conn
-	mu        *sync.Mutex
-	sub       *nats.Subscription
-	resumeSeq uint64
+	mgr        *jsm.Manager
+	stream     *jsm.Stream
+	consumer   *jsm.Consumer
+	cfg        api.StreamConfig
+	nc         *nats.Conn
+	mu         *sync.Mutex
+	sub        *nats.Subscription
+	resumeSeq  uint64
+	resumeTime time.Time
 }
 
 const (


### PR DESCRIPTION
If we detect that a Purge probably happened on resume we
will continue from the last message time, this only works
in the case where there is no messages in the stream at all
when we ask for the last sequence.

In other cases we will copy all the data.

Signed-off-by: R.I.Pienaar <rip@devco.net>