### PR TITLE
(#83) Add Heartbeats to streams

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/choria-io/stream-replicator/advisor"
+	"github.com/choria-io/stream-replicator/heartbeat"
 	"github.com/choria-io/stream-replicator/idtrack"
 	"github.com/choria-io/tokens"
 	"github.com/nats-io/jsm.go"
@@ -447,6 +448,18 @@ func (c *cmd) replicateAction(_ *fisk.ParseContext) error {
 				c.log.Errorf("Could not start replicator for %s: %v", s.Name, err)
 			}
 		}(s)
+	}
+
+	if cfg.HeartBeat != nil {
+		hb, err := heartbeat.New(cfg.HeartBeat, cfg.ReplicatorName, c.log)
+		if err != nil {
+			c.log.Errorf("Could not initialize heartbeat: %v", err)
+		} else {
+			err = hb.Run(ctx, wg)
+			if err != nil {
+				c.log.Errorf("Could not start heartbeat: %v", err)
+			}
+		}
 	}
 
 	wg.Wait()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -160,5 +160,30 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Validate()).To(MatchError("only one inspection mode can be set per stream"))
 
 		})
+
+		It("Should validate the required fields in heartbeat", func() {
+			cfg.HeartBeat = &HeartBeat{}
+			Expect(cfg.Validate()).To(MatchError("url is required with heartbeat"))
+
+			cfg.HeartBeat.URL = "nats://foo.com:4222"
+			Expect(cfg.Validate()).To(MatchError("heartbeat requires at least one subject"))
+
+			cfg.HeartBeat.Subjects = []Subject{
+				{},
+			}
+			Expect(cfg.Validate()).To(MatchError("name is required with subject"))
+
+			cfg.HeartBeat.Subjects = []Subject{
+				{
+					Name: "s.1",
+				},
+			}
+
+			cfg.HeartBeat.Interval = "1o"
+			Expect(cfg.Validate()).To(MatchError("invalid interval: invalid time unit o"))
+
+			cfg.HeartBeat.Interval = "1s"
+			Expect(cfg.Validate()).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/election/options.go
+++ b/election/options.go
@@ -56,3 +56,8 @@ func WithDebug(cb func(format string, a ...any)) Option {
 func WithReplicator(r string) Option {
 	return func(o *options) { o.replicator = r }
 }
+
+// SkipTTLValidateForTests turns off Bucket TTL validation for testing
+func SkipTTLValidateForTests() {
+	skipValidate = true
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.8.3
 	github.com/onsi/gomega v1.27.1
 	github.com/prometheus/client_golang v1.14.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/tidwall/gjson v1.14.4
@@ -35,7 +36,6 @@ require (
 	github.com/nats-io/jwt/v2 v2.3.0 // indirect
 	github.com/nats-io/nkeys v0.3.0 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2022-2023, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package heartbeat defines the heartbeat system that starts up along side the stream replicator.
+// If configured it will send a heartbeat messages to the configured subjects on a configurable interval.
+package heartbeat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/choria-io/stream-replicator/backoff"
+	"github.com/choria-io/stream-replicator/config"
+	"github.com/choria-io/stream-replicator/election"
+	"github.com/choria-io/stream-replicator/internal/util"
+	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultUpdateInterval = "10s"
+	OriginatorHeader      = "Choria-SR-Originator"
+	SubjectHeader         = "Choria-SR-Subject"
+)
+
+var (
+	enableBackoff = true
+)
+
+type HeartBeat struct {
+	url            string
+	replicatorName string
+	electionName   string
+	tls            config.TLS
+	choria         config.ChoriaConnection
+	leaderElection bool
+	interval       string
+	headers        map[string]string
+	subjects       []*Subject
+	log            *logrus.Entry
+	paused         atomic.Bool
+}
+
+type Subject struct {
+	name     string
+	interval time.Duration
+	headers  map[string]string
+}
+
+// New creates a new instance of the Heartbeat struct
+func New(hbcfg *config.HeartBeat, replicatorName string, log *logrus.Entry) (*HeartBeat, error) {
+	hb := &HeartBeat{
+		replicatorName: replicatorName,
+		electionName:   fmt.Sprintf("%s_HB", replicatorName),
+		tls:            hbcfg.TLS,
+		choria:         hbcfg.Choria,
+		leaderElection: hbcfg.LeaderElection,
+		headers:        hbcfg.Headers,
+		log:            log,
+		url:            hbcfg.URL,
+	}
+
+	if hb.headers == nil {
+		hb.headers = make(map[string]string)
+	}
+
+	hb.paused.Store(hb.leaderElection)
+
+	hb.interval = DefaultUpdateInterval
+	if hbcfg.Interval != "" {
+		hb.interval = hbcfg.Interval
+	}
+
+	for _, s := range hbcfg.Subjects {
+		var err error
+		sub := &Subject{name: s.Name}
+		if s.Interval == "" {
+			s.Interval = hb.interval
+		}
+
+		sub.interval, err = util.ParseDurationString(s.Interval)
+		if err != nil {
+			return nil, err
+		}
+
+		if s.Headers == nil {
+			s.Headers = make(map[string]string)
+		}
+		sub.headers = s.Headers
+
+		for k, v := range hb.headers {
+			if _, ok := sub.headers[k]; ok {
+				continue
+			}
+			sub.headers[k] = v
+		}
+		hb.subjects = append(hb.subjects, sub)
+	}
+
+	return hb, nil
+}
+
+// Run initializes a the jetstream connection and spawns a go routine for every configured subject
+// that will publish a heartbeat message on the defined interval
+func (hb *HeartBeat) Run(ctx context.Context, wg *sync.WaitGroup) error {
+	nc, err := util.ConnectNats(ctx, "subject-heartbeats", hb.url, &hb.tls, &hb.choria, false, hb.log)
+	if err != nil {
+		return err
+	}
+
+	if hb.leaderElection {
+		err = hb.setupElection(ctx, nc)
+		if err != nil {
+			hb.log.Errorf("Could not set up elections: %v", err)
+			return err
+		}
+	}
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("unable to create jetstream context: %v", err)
+	}
+
+	for _, subject := range hb.subjects {
+		wg.Add(1)
+		hbSubjects.WithLabelValues(hb.replicatorName, subject.name).Inc()
+		go heartBeatWorker(ctx, wg, subject, nc, js, hb.replicatorName, &hb.paused, hb.log.WithField("subject", subject.name))
+	}
+
+	return nil
+}
+
+func heartBeatWorker(ctx context.Context, wg *sync.WaitGroup, sub *Subject, nc *nats.Conn, js nats.JetStreamContext, replicatorName string, paused *atomic.Bool, log *logrus.Entry) {
+	defer wg.Done()
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Warn("Unable to determine hostname. Publishing heartbeats with empty 'originator' header.")
+	}
+
+	msg := nats.NewMsg(sub.name)
+	for k, v := range sub.headers {
+		msg.Header.Add(k, v)
+	}
+
+	if hostname != "" {
+		msg.Header.Add(OriginatorHeader, hostname)
+	}
+
+	msg.Header.Add(SubjectHeader, sub.name)
+
+	ticker := time.NewTicker(sub.interval)
+	if enableBackoff {
+		ticker.Reset(1 * time.Hour)
+		time.AfterFunc(backoff.FiveSec.Duration(10), func() { ticker.Reset(sub.interval) })
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			if paused.Load() {
+				log.Debug("Not sending heartbeat when paused")
+				continue
+			}
+			msg.Data = []byte(strconv.Itoa(int(time.Now().Unix())))
+
+			timer := hbPublishTime.WithLabelValues(replicatorName, sub.name)
+			obs := prometheus.NewTimer(timer)
+			log.Debugf("Sending heartbeat message")
+			_, err := js.PublishMsg(msg, nats.AckWait(2*time.Second))
+			obs.ObserveDuration()
+
+			// Check the function PublishMSG
+			if err != nil {
+				hbPublishedCtrErr.WithLabelValues(replicatorName, sub.name).Inc()
+				log.Errorf("Unable to publish message to subject: %v", err)
+			}
+
+			hbPublishedCtr.WithLabelValues(replicatorName, sub.name).Inc()
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (hb *HeartBeat) setupElection(ctx context.Context, nc *nats.Conn) error {
+	js, err := nc.JetStream()
+	if err != nil {
+		return err
+	}
+
+	kv, err := js.KeyValue("CHORIA_LEADER_ELECTION")
+	if err != nil {
+		return err
+	}
+
+	win := func() {
+		hb.log.Warnf("%s became the leader", hb.replicatorName)
+		hb.paused.Store(false)
+		hbPaused.WithLabelValues(hb.replicatorName).Set(1.0)
+	}
+
+	lost := func() {
+		hb.log.Warnf("%s lost the leadership", hb.replicatorName)
+		hb.paused.Store(true)
+		hbPaused.WithLabelValues(hb.replicatorName).Set(0)
+	}
+
+	e, err := election.NewElection(hb.electionName, "heartbeat", kv, election.WithBackoff(backoff.FiveSec), election.OnWon(win), election.OnLost(lost))
+	if err != nil {
+		return err
+	}
+
+	go e.Start(ctx)
+
+	hb.log.Infof("Set up leader election 'heartbeat' using candidate name %s", hb.electionName)
+	return nil
+}

--- a/heartbeat/heartbeat_test.go
+++ b/heartbeat/heartbeat_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2022-2023, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package heartbeat
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/choria-io/stream-replicator/config"
+	"github.com/choria-io/stream-replicator/election"
+	"github.com/choria-io/stream-replicator/internal/testutil"
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats.go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestHeartBeat(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "heartbeat")
+}
+
+var _ = Describe("Subject Heartbeat", func() {
+	var (
+		ctx      context.Context
+		cancel   context.CancelFunc
+		wg       = sync.WaitGroup{}
+		log      *logrus.Entry
+		hbConfig config.HeartBeat
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		logger := logrus.New()
+		logger.SetOutput(GinkgoWriter)
+		log = logrus.NewEntry(logger)
+
+		DeferCleanup(func() {
+			cancel()
+			wg.Wait()
+		})
+
+		hbConfig = config.HeartBeat{
+			LeaderElection: false,
+			Subjects: []config.Subject{
+				{
+					Name:     "heartbeat",
+					Interval: "500ms",
+				},
+			},
+		}
+		enableBackoff = false
+		election.SkipTTLValidateForTests()
+	})
+
+	// for use with Eventually()
+	streamMesssage := func(s *jsm.Stream) func() (uint64, error) {
+		return func() (uint64, error) {
+			nfo, err := s.State()
+			if err != nil {
+				return 0, err
+			}
+			return nfo.Msgs, nil
+		}
+	}
+
+	Describe("run", func() {
+		It("should send at least 1 heart beat message", func() {
+			testutil.WithJetStream(log, func(nc *nats.Conn, mgr *jsm.Manager) {
+				jstream, err := mgr.NewStream("TEST", jsm.Subjects("heartbeat"))
+				Expect(err).ToNot(HaveOccurred())
+				hbConfig.URL = nc.ConnectedUrl()
+
+				hb, err := New(&hbConfig, "test_replicator", log)
+				Expect(err).ToNot(HaveOccurred())
+
+				go func() {
+					defer GinkgoRecover()
+					err = hb.Run(ctx, &wg)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				defer cancel()
+				Eventually(streamMesssage(jstream)).Should(BeNumerically(">=", 1))
+			})
+		})
+
+		It("should send to multiple subjects", func() {
+			testutil.WithJetStream(log, func(nc *nats.Conn, mgr *jsm.Manager) {
+				hbConfig.Subjects = append(hbConfig.Subjects, config.Subject{
+					Name:     "heartbeat2",
+					Interval: "500ms",
+				})
+				jstream, err := mgr.NewStream("TEST", jsm.Subjects("heartbeat"))
+				Expect(err).ToNot(HaveOccurred())
+				jstream2, err := mgr.NewStream("TEST", jsm.Subjects("heartbeat"))
+				Expect(err).ToNot(HaveOccurred())
+				hbConfig.URL = nc.ConnectedUrl()
+
+				hb, err := New(&hbConfig, "test_replicator", log)
+				Expect(err).ToNot(HaveOccurred())
+
+				go func() {
+					defer GinkgoRecover()
+					err = hb.Run(ctx, &wg)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				defer cancel()
+				Eventually(streamMesssage(jstream)).Should(BeNumerically(">=", 1))
+				Eventually(streamMesssage(jstream2)).Should(BeNumerically(">=", 1))
+			})
+		})
+
+		It("should send a well formed message", func() {
+			testutil.WithJetStream(log, func(nc *nats.Conn, mgr *jsm.Manager) {
+				jstream, err := mgr.NewStream("TEST", jsm.Subjects("heartbeat"))
+				Expect(err).ToNot(HaveOccurred())
+				hbConfig.URL = nc.ConnectedUrl()
+				hostname, _ := os.Hostname()
+				hbConfig.Headers = map[string]string{
+					"test1": "value1",
+				}
+				hbConfig.Subjects[0].Headers = map[string]string{
+					"test2": "value2",
+				}
+
+				hb, err := New(&hbConfig, "test_replicator", log)
+				Expect(err).ToNot(HaveOccurred())
+
+				go func() {
+					defer GinkgoRecover()
+					err = hb.Run(ctx, &wg)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				defer cancel()
+				Eventually(streamMesssage(jstream)).Should(BeNumerically(">=", 1))
+
+				x, err := nc.JetStream()
+				Expect(err).ToNot(HaveOccurred())
+				sub, err := x.PullSubscribe("heartbeat", "")
+				Expect(err).ToNot(HaveOccurred())
+				msgs, err := sub.Fetch(1)
+				Expect(err).ToNot(HaveOccurred())
+
+				log.Errorf("Body is: %s", msgs[0].Data)
+				timestamp, err := strconv.ParseInt(string(msgs[0].Data), 10, 64)
+				Expect(err).ToNot(HaveOccurred())
+				tm := time.Unix(timestamp, 0)
+
+				Expect(tm).To(BeTemporally("~", time.Now().Add(-1*time.Second), 1*time.Second))
+				Expect(msgs[0].Subject).To(Equal("heartbeat"))
+				Expect(msgs[0].Header.Get(OriginatorHeader)).To(Equal(hostname))
+				Expect(msgs[0].Header.Get(SubjectHeader)).To(Equal("heartbeat"))
+				Expect(msgs[0].Header.Get("test1")).To(Equal("value1"))
+				Expect(msgs[0].Header.Get("test2")).To(Equal("value2"))
+			})
+		})
+
+		It("should perform leader election and set metrics", func() {
+			testutil.WithJetStream(log, func(nc *nats.Conn, mgr *jsm.Manager) {
+				hbConfig.LeaderElection = true
+				jstream, err := mgr.NewStream("TEST", jsm.Subjects("heartbeat"))
+				Expect(err).ToNot(HaveOccurred())
+
+				js, err := nc.JetStream()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = js.CreateKeyValue(&nats.KeyValueConfig{
+					Bucket: "CHORIA_LEADER_ELECTION",
+					TTL:    750 * time.Millisecond,
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				hbConfig.LeaderElection = true
+				hbConfig.URL = nc.ConnectedUrl()
+
+				hb1, err := New(&hbConfig, "test_replicator1_HB", log)
+				Expect(err).ToNot(HaveOccurred())
+
+				hb2, err := New(&hbConfig, "test_replicator2_HB", log)
+				Expect(err).ToNot(HaveOccurred())
+
+				go func() {
+					defer GinkgoRecover()
+					err = hb1.Run(ctx, &wg)
+					Expect(err).ToNot(HaveOccurred())
+					err = hb2.Run(ctx, &wg)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				defer cancel()
+				Eventually(streamMesssage(jstream), "6s").Should(BeNumerically(">=", 1))
+				Expect(hb1.paused.Load() != hb2.paused.Load()).To(BeTrue())
+
+				activeReplicator := "test_replicator1_HB"
+				inactiveReplicator := "test_replicator2_HB"
+				if hb1.paused.Load() == true {
+					activeReplicator = "test_replicator2_HB"
+					inactiveReplicator = "test_replicator1_HB"
+				}
+				Expect(getPromGaugeValue(hbSubjects, activeReplicator, "heartbeat")).To(Equal(1.0))
+				Expect(getPromCountValue(hbPublishedCtr, activeReplicator, "heartbeat")).To(BeNumerically(">=", 1.0))
+				Expect(getPromCountValue(hbPublishedCtrErr, activeReplicator, "heartbeat")).To(Equal(0.0))
+				Expect(getPromGaugeValue(hbPaused, inactiveReplicator)).To(Equal(0.0))
+				Expect(getPromGaugeValue(hbPaused, activeReplicator)).To(Equal(1.0))
+			})
+		})
+	})
+})
+
+func getPromCountValue(ctr *prometheus.CounterVec, labels ...string) float64 {
+	pb := &dto.Metric{}
+	m, err := ctr.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+
+	if m.Write(pb) != nil {
+		return 0
+	}
+
+	return pb.GetCounter().GetValue()
+}
+
+func getPromGaugeValue(ctr *prometheus.GaugeVec, labels ...string) float64 {
+	pb := &dto.Metric{}
+	m, err := ctr.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+
+	if m.Write(pb) != nil {
+		return 0
+	}
+
+	return pb.GetGauge().GetValue()
+}

--- a/heartbeat/stats.go
+++ b/heartbeat/stats.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2022-2023, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package heartbeat
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// gauge
+	hbSubjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "hb_subjects"),
+		Help: "Number of subjects that heartbeats are being published for",
+	}, []string{"replicator", "subject"})
+	hbPublishedCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "hb_published_ctr"),
+		Help: "Number of published messages",
+	}, []string{"replicator", "subject"})
+	hbPublishedCtrErr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "hb_published_error_ctr"),
+		Help: "Number of published message errors",
+	}, []string{"replicator", "subject"})
+	hbPublishTime = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "hb_publish_time"),
+		Help: "Time taken to publish a message",
+	}, []string{"replicator", "subject"})
+	hbPaused = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName("choria_stream_replicator", "replicator", "hb_paused"),
+		Help: "Paused under leader election",
+	}, []string{"replicator"})
+)
+
+func init() {
+	prometheus.MustRegister(hbSubjects)
+	prometheus.MustRegister(hbPublishedCtr)
+	prometheus.MustRegister(hbPublishedCtrErr)
+	prometheus.MustRegister(hbPublishTime)
+	prometheus.MustRegister(hbPaused)
+}


### PR DESCRIPTION
Here we add the ability to configure heartbeat messages for streams.

By adding a new heartbeat section to the configuration file, and specifying specific streams, stream-replicator will send a message with a unix timestamp as the body at a predetermined interval. This can be used to monitor availability when streams are mostly idle.

The heartbeat package will spawn a goroutine for every configured subject and send a message on interval. The heartbeat publisher is leader aware and adds relevant prometheus metrics.