### PR TITLE
(misc) Improve getHostname method

### DIFF
--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -237,11 +237,7 @@ func (hb *HeartBeat) getHostName() (string, error) {
 		rval := stubHostname
 		stubHostname = ""
 		return rval, nil
-	} else {
-		hostname, err := os.Hostname()
-		if err != nil {
-			return "", err
-		}
-		return hostname, nil
 	}
+
+	return os.Hostname()
 }

--- a/heartbeat/heartbeat_test.go
+++ b/heartbeat/heartbeat_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Subject Heartbeat", func() {
 					Expect(err).ToNot(HaveOccurred())
 				}()
 				defer cancel()
-				Eventually(streamMesssage(jstream), "5s").Should(BeNumerically(">=", 1))
+				Eventually(streamMesssage(jstream), "10s").Should(BeNumerically(">=", 1))
 				Eventually(hb1.paused.Load() == hb2.paused.Load(), "10s").Should(BeFalse())
 
 				if !hb1.paused.Load() {


### PR DESCRIPTION
Rewrite the getHostname method in heartbeat and up the test timeout to reduce failures on slower machines.