### PR TITLE
(#146) - Support for building el9 packages

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,6 +35,21 @@ jobs:
           packager_tag: el8-go1.20
           version: nightly
 
+  el9_64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: src/github.com/choria-io/aaasvc
+
+      - name: Build
+        uses: choria-io/actions/packager@main
+        with:
+          build_package: el9_64
+          packager_tag: el9-go1.20
+          version: nightly
+
   docker:
     needs:
       - upload
@@ -54,6 +69,7 @@ jobs:
     needs:
       - el7_64
       - el8_64
+      - el9_64
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          path: src/github.com/choria-io/aaasvc
+          path: src/github.com/choria-io/stream-replicator
 
       - name: Build
         uses: choria-io/actions/packager@main
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          path: src/github.com/choria-io/aaasvc
+          path: src/github.com/choria-io/stream-replicator
 
       - name: Build
         uses: choria-io/actions/packager@main
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          path: src/github.com/choria-io/aaasvc
+          path: src/github.com/choria-io/stream-replicator
 
       - name: Build
         uses: choria-io/actions/packager@main

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -29,3 +29,9 @@ foss:
       template: el/el8
       target_arch: x86_64
       binary: 64bit_linux
+    
+    el9_64:
+      dist: el9
+      template: el/el9
+      target_arch: x86_64
+      binary: 64bit_linux

--- a/packager/templates/el/el9/config.yaml
+++ b/packager/templates/el/el9/config.yaml
@@ -1,0 +1,11 @@
+required_properties:
+  - name
+  - bindir
+  - etcdir
+  - release
+  - dist
+
+artifacts:
+  - /usr/src/redhat/**/*.rpm
+  - /root/rpmbuild/**/*.rpm
+

--- a/packager/templates/el/el9/stream-replicator.service
+++ b/packager/templates/el/el9/stream-replicator.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=The Choria NATS JetStream Stream Replicator
+After=network.target
+
+[Service]
+StandardOutput=syslog
+StandardError=syslog
+User=nobody
+Group=nobody
+ExecStart={{cpkg_bindir}}/{{cpkg_name}} replicate --config={{cpkg_etcdir}}/sr.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/packager/templates/el/el9/stream-replicator.spec
+++ b/packager/templates/el/el9/stream-replicator.spec
@@ -1,0 +1,73 @@
+%define debug_package %{nil}
+%define pkgname {{cpkg_name}}
+%define version {{cpkg_version}}
+%define bindir {{cpkg_bindir}}
+%define etcdir {{cpkg_etcdir}}
+%define release {{cpkg_release}}
+%define dist {{cpkg_dist}}
+%define binary {{cpkg_binary}}
+%define tarball {{cpkg_tarball}}
+
+Name: %{pkgname}
+Version: %{version}
+Release: %{release}.%{dist}
+Summary: The Choria NATS JetStream Stream Replicator
+License: Apache-2.0
+URL: https://choria.io
+Group: System Tools
+Packager: R.I.Pienaar <rip@devco.net>
+Source0: %{tarball}
+BuildRoot: %{_tmppath}/%{pkgname}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+Replicator for NATS JetStream Streams
+
+%prep
+%setup -q
+
+%build
+
+%install
+rm -rf %{buildroot}
+%{__install} -d -m0755  %{buildroot}/usr/lib/systemd/system
+%{__install} -d -m0755  %{buildroot}/etc/logrotate.d
+%{__install} -d -m0755  %{buildroot}%{bindir}
+%{__install} -d -m0755  %{buildroot}%{etcdir}
+%{__install} -d -m0755  %{buildroot}/var/log
+%{__install} -d -m0756  %{buildroot}/var/lib/%{pkgname}
+%{__install} -m0644 dist/stream-replicator.service %{buildroot}/usr/lib/systemd/system/%{pkgname}.service
+%{__install} -m0644 dist/logrotate %{buildroot}/etc/logrotate.d/%{pkgname}
+%{__install} -m0640 dist/sr.yaml %{buildroot}%{etcdir}/sr.yaml
+%{__install} -m0755 %{binary} %{buildroot}%{bindir}/%{pkgname}
+touch %{buildroot}/var/log/%{pkgname}.log
+
+%clean
+rm -rf %{buildroot}
+
+%post
+if [ $1 -eq 1 ] ; then
+  systemctl --no-reload preset %{pkgname} >/dev/null 2>&1 || :
+fi
+
+/bin/systemctl --system daemon-reload >/dev/null 2>&1 || :
+
+if [ $1 -ge 1 ]; then
+  /bin/systemctl try-restart %{pkgname} >/dev/null 2>&1 || :;
+fi
+
+%preun
+if [ $1 -eq 0 ] ; then
+  systemctl --no-reload disable --now %{pkgname} >/dev/null 2>&1 || :
+fi
+
+%files
+%attr(640, root, nobody) %config(noreplace)%{etcdir}/sr.yaml
+%{bindir}/%{pkgname}
+/etc/logrotate.d/%{pkgname}
+/usr/lib/systemd/system/%{pkgname}.service
+%attr(644, nobody, nobody)/var/log/%{pkgname}.log
+%attr(740, nobody, nobody)/var/lib/%{pkgname}
+
+%changelog
+* Tue Dec 26 2017 R.I.Pienaar <rip@devco.net>
+- Initial Release


### PR DESCRIPTION
(#146) added support for el9 packages to be built using a template of el8. Also added support for building el9 packages to the nightly build in the github workflow