### PR TITLE
(#146) add el9 package run to the release github workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,10 +25,21 @@ jobs:
           packager_tag: el8-go1.21
           version: tag
 
+  el9_64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        uses: choria-io/actions/packager@main
+        with:
+          build_package: el9_64
+          packager_tag: el9-go1.21
+          version: tag
+
   upload:
     needs:
       - el7_64
       - el8_64
+      - el9_64
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Added the el9 package that was created to run only in the nightly builds to also run in the release builds