### PR TITLE
(#157) Configure Tls handshake first, insecure and connect_timeout via NATS URL

### DIFF
--- a/docs/content/configuration/basic/_index.md
+++ b/docs/content/configuration/basic/_index.md
@@ -56,6 +56,31 @@ We support using NATS credentials, JWT and NKey files for authentication by addi
 | Credentials file      | `nats://example.net:4222?credentials=/path/to/creds`              |
 | JWT and NKey files    | `nats://example.net:4222?jwt=/path/to/my.jwt&nkey=/path/to/my.nk` |
 
+## Connection URL Options
+
+You can further tune the client connection by adding query parameters to any Source or Target NATS URL. These options can be combined with credentials.
+
+| Option                | Values         | Purpose                                                                 | Example                                                       |
+|-----------------------|----------------|-------------------------------------------------------------------------|---------------------------------------------------------------|
+| `tls_handshake_first` | `true`/`false` | Perform TLS handshake before the NATS INFO protocol. Useful with some load balancers/proxies. Only meaningful when TLS is used. | `nats://example.net:4222?tls_handshake_first=true`           |
+| `insecure`            | `true`/`false` | Skip TLS certificate verification (InsecureSkipVerify). For testing only. | `nats://example.net:4222?insecure=true`                       |
+| `connect_timeout`     | duration       | Client connect timeout. Supports values like `500ms`, `2s`, `1m30s`.    | `nats://example.net:4222?connect_timeout=1500ms`             |
+
+Examples:
+
+```yaml
+# Minimal examples
+streams:
+  - first:
+      source: nats://source.example.net:4222?connect_timeout=2s
+      target: nats://target.example.net:4222?tls_handshake_first=true
+
+# Combined with credentials
+  - second:
+      source: nats://source.example.net:4222?credentials=/etc/nats.creds&connect_timeout=5s
+      target: nats://target.example.net:4222?jwt=/etc/client.jwt&nkey=/etc/client.nk&insecure=true
+```
+
 ## TLS
 
 TLS is supported, one can have per Target or Source settings.  Per Stream settings or per Replicator settings.  The most specific will be used for example, given this partial configuration file:

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,130 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	server "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+// startTestServer starts an in-process NATS server and returns a stop func.
+func startTestServer(t *testing.T) (url string, stop func()) {
+	t.Helper()
+
+	opts := &server.Options{
+		Port:   -1,
+		NoLog:  true,
+		NoSigs: true,
+	}
+	s, err := server.NewServer(opts)
+	if err != nil {
+		t.Fatalf("failed to create nats server: %v", err)
+	}
+	go s.Start()
+	if !s.ReadyForConnections(5 * time.Second) {
+		s.Shutdown()
+		t.Fatalf("nats server not ready in time")
+	}
+	return s.ClientURL(), func() { s.Shutdown() }
+}
+
+type noTLS struct{}
+
+func (noTLS) CertificateAuthority() string { return "" }
+func (noTLS) PublicCertificate() string    { return "" }
+func (noTLS) PrivateKey() string           { return "" }
+
+// minimal logger entry for tests
+func testLogger() *logrus.Entry {
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel)
+	return logrus.NewEntry(l)
+}
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Options Suite")
+}
+
+var _ = Describe("buildNatsOptions", func() {
+	var (
+		nurl string
+		stop func()
+	)
+
+	BeforeEach(func() {
+		nurl, stop = startTestServer(&testing.T{})
+	})
+
+	AfterEach(func() {
+		if stop != nil {
+			stop()
+		}
+	})
+
+	It("enables TLSHandshakeFirst when tls_handshake_first=true and tls config is set", func() {
+		srv := nurl + "?tls_handshake_first=true"
+		opts, _, err := buildNatsOptions("test", srv, noTLS{}, nil, false, nil, testLogger())
+		Expect(err).ToNot(HaveOccurred())
+		var nopts nats.Options
+		for _, o := range opts {
+			err := o(&nopts)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(nopts.TLSHandshakeFirst).To(BeTrue())
+	})
+
+	It("disable TLSHandshakeFirst when tls_handshake_first=true and tls config is not set", func() {
+		srv := nurl + "?tls_handshake_first=true"
+		opts, _, err := buildNatsOptions("test", srv, nil, nil, false, nil, testLogger())
+		Expect(err).ToNot(HaveOccurred())
+		var nopts nats.Options
+		for _, o := range opts {
+			err := o(&nopts)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(nopts.TLSHandshakeFirst).To(BeFalse())
+	})
+
+	It("defaults TLSHandshakeFirst to false when flag absent", func() {
+		srv := nurl
+		opts, _, err := buildNatsOptions("test", srv, noTLS{}, nil, false, nil, testLogger())
+		Expect(err).ToNot(HaveOccurred())
+		var nopts nats.Options
+		for _, o := range opts {
+			err := o(&nopts)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(nopts.TLSHandshakeFirst).To(BeFalse())
+	})
+
+	It("sets TLS InsecureSkipVerify when insecure=true", func() {
+		srv := nurl + "?insecure=true"
+		opts, _, err := buildNatsOptions("test", srv, noTLS{}, nil, false, nil, testLogger())
+		Expect(err).ToNot(HaveOccurred())
+		var nopts nats.Options
+		for _, o := range opts {
+			err := o(&nopts)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(nopts.Secure).To(BeTrue())
+		Expect(nopts.TLSConfig).ToNot(BeNil())
+		Expect(nopts.TLSConfig.InsecureSkipVerify).To(BeTrue())
+	})
+
+	It("sets connect timeout from query param", func() {
+		srv := nurl + "?connect_timeout=1500ms"
+		opts, _, err := buildNatsOptions("test", srv, noTLS{}, nil, false, nil, testLogger())
+		Expect(err).ToNot(HaveOccurred())
+		var nopts nats.Options
+		for _, o := range opts {
+			err := o(&nopts)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(nopts.Timeout).To(Equal(1500 * time.Millisecond))
+	})
+})


### PR DESCRIPTION
Adding NATS options `tls_handshake_first`, `insecure` and `connect_timeout` configurable via Source/Target URL.
